### PR TITLE
Make more 2to3-friendly

### DIFF
--- a/dcp_parser/atomic/atoms.py
+++ b/dcp_parser/atomic/atoms.py
@@ -1,6 +1,9 @@
 """ Definitions of atomic functions """
 import abc
-import exceptions
+try:  # No exceptions module in Python 3
+    import exceptions
+except ImportError:
+    pass
 import copy
 from types import MethodType
 from numbers import Number

--- a/dcp_parser/parser.py
+++ b/dcp_parser/parser.py
@@ -1,7 +1,7 @@
 from expression.statement import Statement
 from expression.expression import Parameter, Variable, Constant
 from expression.sign import Sign
-import atomic.atom_loader
+import dcp_parser.atomic.atom_loader as atom_loader
 import ply.yacc
 
 class Parser(object):
@@ -14,7 +14,7 @@ class Parser(object):
     """
     def __init__(self):
         self.clear()
-        self.atom_dict = atomic.atom_loader.generate_atom_dict()
+        self.atom_dict = atom_loader.generate_atom_dict()
         self.parser = self.build_parser()
 
     # Dump previous input.

--- a/dcp_parser/tests/test_atoms.py
+++ b/dcp_parser/tests/test_atoms.py
@@ -126,7 +126,7 @@ class TestAtoms(object):
         try:
             Log_sum_exp()
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), "No arguments given to 'log_sum_exp'.")
 
         assert_equals(len(Log_sum_exp(self.conc_exp, self.cvx_exp).arguments()), 2)
@@ -282,21 +282,21 @@ class TestAtoms(object):
         try:
             Norm(Constant(-2), 0)
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), "Invalid value '0' for p in norm(..., p).")
 
         # Check error message
         try:
             Norm(Constant(-2), 'not inf')
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), "Invalid value 'not inf' for p in norm(..., p).")
 
         # Check error message
         try:
             Norm()
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), "No arguments given to 'norm'.")
 
     def test_abs(self):
@@ -322,7 +322,7 @@ class TestAtoms(object):
         try:
             Berhu(Constant(-2), 0)
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), "Invalid value '0' for M in berhu(...,M).")
 
     def test_entr(self):
@@ -350,7 +350,7 @@ class TestAtoms(object):
         try:
             Huber(Constant(-2), 0)
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), "Invalid value '0' for M in huber(...,M).")
 
     def test_huber_pos(self):
@@ -366,7 +366,7 @@ class TestAtoms(object):
         try:
             Huber_pos(Constant(-2), 0)
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), "Invalid value '0' for M in huber_pos(...,M).")
 
     def test_huber_circ(self):
@@ -382,7 +382,7 @@ class TestAtoms(object):
         try:
             Huber_circ(Constant(-2), 0)
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), "Invalid value '0' for M in huber_circ(...,M).")
 
     def test_inv_pos(self):
@@ -420,7 +420,7 @@ class TestAtoms(object):
         try:
             Norm_largest(Constant(-2), 'invalid')
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), "Invalid value 'invalid' for k in norm_largest(...,k).")
 
     def test_pos(self):
@@ -462,7 +462,7 @@ class TestAtoms(object):
         try:
             Pow(Constant(-2), 'wrong')
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), "Invalid value 'wrong' for p in pow(..., p).")
 
     def test_pow_abs(self):
@@ -479,7 +479,7 @@ class TestAtoms(object):
         try:
             Pow_abs(Constant(-2), 0)
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), 'Must have p >= 1 for pow_abs(..., p), but have p = 0.')
 
     def test_pow_pos(self):
@@ -495,7 +495,7 @@ class TestAtoms(object):
         try:
             Pow_pos(Constant(-2), 0)
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), 'Must have p >= 1 for pow_pos(..., p), but have p = 0.')
 
     def test_square_abs(self):
@@ -587,7 +587,7 @@ class TestAtoms(object):
         try:
             Sum_largest(self.cvx_pos, 'invalid')
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), "Invalid value 'invalid' for k in sum_largest(...,k).")
 
     def test_sum_smallest(self):
@@ -604,5 +604,5 @@ class TestAtoms(object):
         try:
             Sum_smallest(self.cvx_pos, 'invalid')
             assert False
-        except Exception, e:
+        except Exception as e:
             assert_equals(str(e), "Invalid value 'invalid' for k in sum_smallest(...,k).")

--- a/dcp_parser/tests/test_parser.py
+++ b/dcp_parser/tests/test_parser.py
@@ -16,110 +16,110 @@ class TestParser(object):
           try:
                self.parser.parse("x < 2")
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "'<' constraints are not valid. Consider using '<='.")
 
           try:
                self.parser.parse("x > 2")
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "'>' constraints are not valid. Consider using '>='.")
 
           try:
                self.parser.parse('a * x = y + b')
                assert False
-          except Exception, e:
+          except Exception as e:
                 assert_equals(str(e), "'=' is not valid. Did you mean '=='?")
 
           try:
                self.parser.parse('x^2')
                assert False
-          except Exception, e:
+          except Exception as e:
                 assert_equals(str(e), "'^' is not valid. Consider using the 'pow' function.")
 
           try:
                self.parser.parse('.')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "Illegal character '.'.")
 
           try:
                self.parser.parse('1 + sum(x,y) + max(1,,)')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "Missing arguments in 'max(1, , )'.")
 
           try:
                self.parser.parse('none')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "'none' is not a known variable or parameter.")
           try:
                self.parser.parse('max()')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "Missing arguments in 'max()'.")
 
           try:
                self.parser.parse('max(1 1)')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "Syntax error in call to 'max'.")
 
           try:
                self.parser.parse('none(x)')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "'none' is not a known function.")
 
           # Arithmetic expression errors.
           try:
                self.parser.parse('1 + sum(x,y) + max(1,++)')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "Syntax error in call to 'max'.")
 
 
           try:
                self.parser.parse('-')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "'-' is not a valid expression.")
 
           try:
                self.parser.parse('1--')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "'1--' is not a valid expression.")
 
           try:
                self.parser.parse('1<= ==')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "Invalid syntax after '1'.")
 
           try:
                self.parser.parse('1 + >= max(1)')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "Invalid syntax after '1'.")
 
           try:
                self.parser.parse('1 == 1 == 1')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "An expression can only contain one constraint.")
 
           try:
                self.parser.parse('1 + 1 -2 <= 3*5 - x + max(x) <= 2')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "An expression can only contain one constraint.")
 
           try:
                self.parser.parse('1 + (1 == 1)')
                assert False
-          except Exception, e:
+          except Exception as e:
                assert_equals(str(e), "Invalid syntax after '1'.")
 
       def test_parse_variables(self):

--- a/demo.py
+++ b/demo.py
@@ -19,12 +19,12 @@ def parse_file(parser):
             filename = get_filename()
             f = open(filename, 'r')
             break
-        except Exception, e:
+        except Exception as e:
             print "Invalid filename"
     for line in f.readlines():
         try:
           parser.parse(line)
-        except Exception, e:
+        except Exception as e:
           print "Error parsing " + line
 
 def select_expression(expressions):
@@ -46,7 +46,7 @@ def display_root(exp):
     print "Current expression: %s" % exp
     try:
         print "Curvature: %s, Sign: %s" % (exp.curvature, exp.sign)
-    except Exception, e: # exp is a Constraint
+    except Exception as e: # exp is a Constraint
         pass 
     for error in exp.errors:
         if error.is_indexed():


### PR DESCRIPTION
Addresses #1.  Specifically:

1. `nosetests` continues to run successfully on python 2.7
1. `2to3 -wn **/*.py` runs without errors, as before
1. `nosetests` under python 3.5 does not fail with syntax or import errors
1. `python demo.py` successfully reads `sample.txt` on python 3.5

FWIW: `nosetests` does not pass on Python 3.5 due to a handful of operator `/` errors.  I am not addressing that 2.7 -> 3.5 issue here.
